### PR TITLE
ref: :lipstick: correções de títulos, textos e dropdown do header

### DIFF
--- a/frontend/src/app/agricultores/novoAgricultor/page.js
+++ b/frontend/src/app/agricultores/novoAgricultor/page.js
@@ -6,7 +6,7 @@ export default function novoAgricultorPage() {
         <div className={styles.pageContainer}>
             <div className={styles.pageContainer__content}>
                 <AgricultorForm 
-                diretorioAnterior="Home / Agricultores /" 
+                diretorioAnterior="Home / Agricultores(as) /" 
                 diretorioAtual="Novo(a) Agricultor(a)" 
                 hrefAnterior="/agricultores" />
             </div>

--- a/frontend/src/app/agricultores/page.js
+++ b/frontend/src/app/agricultores/page.js
@@ -8,7 +8,7 @@ export default function agricultoresPage() {
       <div className={styles.table__bigScreen}>
         <ListAgricultores
           diretorioAnterior="Home /"
-          diretorioAtual="Agricultores"
+          diretorioAtual="Agricultores(as)"
           hrefAnterior="/"
           table1="Nome"
           table2="Nome Popular"
@@ -19,7 +19,7 @@ export default function agricultoresPage() {
       <div className={styles.table__smallScreen}>
         <ListAgricultores
           diretorioAnterior="Home /"
-          diretorioAtual="Agricultores"
+          diretorioAtual="Agricultores(as)"
           hrefAnterior="/"
           table1="Nome"
           table2="Nome Popular"

--- a/frontend/src/app/agricultores/solicitacoes/page.js
+++ b/frontend/src/app/agricultores/solicitacoes/page.js
@@ -6,7 +6,7 @@ export default function solicitacoesPage() {
     <>
         <ListSolicitacoes
           className="content"
-          diretorioAnterior="Home / Agricultores /"
+          diretorioAnterior="Home / Agricultores(as) /"
           diretorioAtual="Solicitações"
           hrefAnterior="/agricultores"
           table1="Nome"

--- a/frontend/src/app/funcionarios/novoFuncionario/page.js
+++ b/frontend/src/app/funcionarios/novoFuncionario/page.js
@@ -7,8 +7,8 @@ export default function novoFuncionarioPage() {
         <div className={styles.pageContainer}>
             <div className={styles.pageContainer__content}>
                 <FuncionarioForm
-                    diretorioAnterior="Home / Funcionários /"
-                    diretorioAtual="Novo(a) Funcionário(a)"
+                    diretorioAnterior="Home / Colaboradores /"
+                    diretorioAtual="Novo(a) Colaborador(a)"
                     hrefAnterior="/funcionarios" />
             </div>
         </div>

--- a/frontend/src/app/funcionarios/page.js
+++ b/frontend/src/app/funcionarios/page.js
@@ -9,7 +9,7 @@ export default function funcionariosPage() {
       <div className={styles.table__bigScreen}>
         <ListFuncionarios
           diretorioAnterior="Home /"
-          diretorioAtual="Funcionários"
+          diretorioAtual="Colaboradores"
           hrefAnterior="/"
           table1="Nome"
           table2="Contato"
@@ -19,7 +19,7 @@ export default function funcionariosPage() {
       <div className={styles.table__smallScreen}>
         <ListFuncionarios
           diretorioAnterior="Home /"
-          diretorioAtual="Funcionários"
+          diretorioAtual="Colaboradores"
           hrefAnterior="/"
           table1="Nome"
           table2="Função"

--- a/frontend/src/app/page.js
+++ b/frontend/src/app/page.js
@@ -54,9 +54,9 @@ const LayoutAdmin = () => {
 
   return (
     <>
-      <Card title="Agricultores" icon="/assets/iconAgricultor.svg" description="Agricultores" link="/agricultores" />
+      <Card title="Agricultores(as)" icon="/assets/iconAgricultor.svg" description="Agricultores" link="/agricultores" />
       <Card title="Coordenadores" icon="/assets/IconCordenadores.svg" description="Coordenadores" link="/coordenadores" />
-      <Card title="Funcionários" icon="/assets/iconAssociates.svg" description="Funcionários" link="/funcionarios" />
+      <Card title="Colaboradores" icon="/assets/iconAssociates.svg" description="Funcionários" link="/funcionarios" />
       <Card title="Bancos de Sementes" icon="/assets/iconBancoDeSementes.svg" description="Banco Sementes" link="/bancoSementes" />
       <Card title="Gestão de Sementes" icon="/assets/iconSeedGreen.svg" description="Sementes" link="/sementes" />
       <Card title="Mural" icon="/assets/iconMural.svg" description="Mural" link="/mural" />
@@ -68,7 +68,7 @@ const LayoutCoordenador = () => {
 
   return (
     <>
-      <Card title="Agricultores" icon="/assets/iconAgricultor.svg" description="Agricultores" link="/agricultores" />
+      <Card title="Agricultores(as)" icon="/assets/iconAgricultor.svg" description="Agricultores" link="/agricultores" />
       <Card title="Bancos de Sementes" icon="/assets/iconBancoDeSementes.svg" description="Banco Sementes" link="/bancoSementes" />
       <Card title="Doações de Sementes" icon="/assets/iconDoacaoDeSementes.svg" description="Doações Sementes" link="/doacoes" />
       <Card title="Retirada de Sementes" icon="/assets/iconRetiradaDeSementes.svg" description="Doações Sementes" link="/retiradas" />
@@ -82,7 +82,7 @@ const LayoutAgricultor = () => {
 
   return (
     <>
-      <Card title="Bancos de Sementes" icon="/assets/iconBancoDeSementes.svg" description="Banco Sementes" link="/bancoSementes" />
+      <Card title="Bancos de Sementes(as)" icon="/assets/iconBancoDeSementes.svg" description="Banco Sementes" link="/bancoSementes" />
       <Card title="Sementes" icon="/assets/iconSeedGreen.svg" description="Sementes" link="/sementes" />
       <Card title="Histórico de Doações" icon="/assets/iconMovimentacaoBancoSementes.svg" description="Doações Sementes" link="/doacoes" />
       <Card title="Histórico de Retirada" icon="/assets/iconMovimentacaoBancoSementes.svg" description="Doações Sementes" link="/retiradas" />

--- a/frontend/src/components/AgricultorForm/DadosEndereco/index.js
+++ b/frontend/src/components/AgricultorForm/DadosEndereco/index.js
@@ -57,7 +57,7 @@ export default function DadosEndereco({ formik }) {
 
   return (
     <>
-      <label htmlFor="cep">Cep <span>*</span></label>
+      <label htmlFor="cep">Cep<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="cep"
@@ -71,7 +71,7 @@ export default function DadosEndereco({ formik }) {
       {formik.touched.cep && formik.errors.endereco.cep ? (
         <span className={style.form__error}>{formik.errors.endereco.cep}</span>
       ) : null}
-      <label htmlFor="estado">Estado <span>*</span></label>
+      <label htmlFor="estado">Estado<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="estado"
@@ -85,7 +85,7 @@ export default function DadosEndereco({ formik }) {
       {formik.touched.estado && formik.errors.endereco.estado ? (
         <span className={style.form__error}>{formik.errors.endereco.estado}</span>
       ) : null}
-      <label htmlFor="cidade">Cidade <span>*</span></label>
+      <label htmlFor="cidade">Cidade<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="cidade"
@@ -99,7 +99,7 @@ export default function DadosEndereco({ formik }) {
       {formik.touched.cidade && formik.errors.endereco.cidade ? (
         <span className={style.form__error}>{formik.errors.endereco.cidade}</span>
       ) : null}
-      <label htmlFor="bairro">Bairro <span>*</span></label>
+      <label htmlFor="bairro">Bairro<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="bairro"
@@ -116,7 +116,7 @@ export default function DadosEndereco({ formik }) {
 
       <div className={style.container__ContainerForm_form_halfContainer}>
         <div>
-          <label htmlFor="logradouro">Logradouro <span>*</span></label>
+          <label htmlFor="logradouro">Logradouro<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="logradouro"
@@ -132,7 +132,7 @@ export default function DadosEndereco({ formik }) {
           ) : null}
         </div>
         <div>
-          <label htmlFor="numero">Número <span>*</span></label>
+          <label htmlFor="numero">Número<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             name="endereco.numero"
@@ -178,7 +178,7 @@ export default function DadosEndereco({ formik }) {
         </div>
       </div>
       <div>
-        <label htmlFor="bancoId">Banco de sementes <span>*</span></label>
+        <label htmlFor="bancoId">Banco de Sementes<span>*</span></label>
         <select
           className={style.container__ContainerForm_form_halfContainer_input}
           id="bancoId"

--- a/frontend/src/components/AgricultorForm/DadosUsuario/index.js
+++ b/frontend/src/components/AgricultorForm/DadosUsuario/index.js
@@ -11,7 +11,7 @@ export default function DadosForm({ formik }) {
   return (
     <>
 
-      <label >E-mail <span>*</span></label>
+      <label >E-mail<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="email"
@@ -26,7 +26,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.email}</span>
       ) : null}
 
-      <label >Senha <span>*</span></label>
+      <label >Senha<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="senha"
@@ -41,7 +41,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.senha}</span>
       ) : null}
 
-      <label >Confirme sua senha <span>*</span></label>
+      <label >Confirme sua Senha<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="confirmarSenha"
@@ -56,7 +56,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.confirmarSenha}</span>
       ) : null}
 
-      <label >Nome <span>*</span></label>
+      <label >Nome<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="nome"
@@ -70,7 +70,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.nome}</span>
       ) : null}
 
-      <label >Apelido <span>*</span></label>
+      <label >Apelido<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="nomePopular"
@@ -84,7 +84,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.nomePopular}</span>
       ) : null}
 
-      <label >CPF <span>*</span></label>
+      <label >CPF<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_halfContainer_input}
         id="cpf"
@@ -103,7 +103,7 @@ export default function DadosForm({ formik }) {
       <div className={style.container__ContainerForm_form_halfContainer}>
 
         <div>
-          <label >Telefone <span>*</span></label>
+          <label >Telefone<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="contato"
@@ -121,7 +121,7 @@ export default function DadosForm({ formik }) {
         </div>
 
         <div>
-          <label >Data de Nascimento <span>*</span></label>
+          <label >Data de Nascimento<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="dataNascimento"
@@ -143,7 +143,7 @@ export default function DadosForm({ formik }) {
       <div className={style.container__ContainerForm_form_halfContainer}>
 
         <div>
-          <label >Sexo <span>*</span></label>
+          <label >Sexo<span>*</span></label>
           <select
             className={style.container__ContainerForm_form_halfContainer_input}
             id="sexo"
@@ -164,7 +164,7 @@ export default function DadosForm({ formik }) {
         </div>
 
         <div>
-          <label >Estado Civil <span>*</span></label>
+          <label >Estado Civil<span>*</span></label>
           <select
             className={style.container__ContainerForm_form_halfContainer_input}
             id="estadoCivil"
@@ -192,7 +192,7 @@ export default function DadosForm({ formik }) {
 
       {estadoCivil === '1' && (
         <div>
-          <label >Nome do Cônjuge <span>*</span></label>
+          <label >Nome do Cônjuge<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="conjugeNome"
@@ -207,7 +207,7 @@ export default function DadosForm({ formik }) {
             <span className={style.form__error}>{formik.errors['conjuge.nome']}</span>
           ) : null}
 
-          <label>Sexo do Cônjuge <span>*</span></label>
+          <label>Sexo do Cônjuge<span>*</span></label>
           <select
             className={style.container__ContainerForm_form_halfContainer_input}
             id="conjugeSexo"

--- a/frontend/src/components/AgricultorForm/agricultorForm.module.scss
+++ b/frontend/src/components/AgricultorForm/agricultorForm.module.scss
@@ -53,7 +53,7 @@
       label {
         margin: 0 0 0.5em 0;
         font-size: 1em;
-        font-weight: normal;
+        font-weight: bold;
 
         &span {
           color: red;

--- a/frontend/src/components/BancoForm/DadosBanco/index.js
+++ b/frontend/src/components/BancoForm/DadosBanco/index.js
@@ -6,7 +6,7 @@ import { cpfMask } from "@/utils/Masks/cpfMask";
 export default function DadosBanco({ formik }) {
   return (
     <>
-      <label htmlFor="nome">Nome do Banco <span>*</span></label>
+      <label htmlFor="nome">Nome do Banco<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="nome"
@@ -21,7 +21,7 @@ export default function DadosBanco({ formik }) {
       ) : null}
       <div className={style.container__ContainerForm_form_halfContainer}>
         <div>
-          <label htmlFor="responsavel">Responsável <span>*</span></label>
+          <label htmlFor="responsavel">Responsável<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="responsavel"
@@ -37,7 +37,7 @@ export default function DadosBanco({ formik }) {
 
         </div>
         <div>
-          <label htmlFor="contato">Telefone <span>*</span></label>
+          <label htmlFor="contato">Telefone<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="contato"
@@ -55,7 +55,7 @@ export default function DadosBanco({ formik }) {
 
         </div>
         <div>
-          <label htmlFor="comunidade">Comunidade <span>*</span></label>
+          <label htmlFor="comunidade">Comunidade<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="comunidade"
@@ -71,7 +71,7 @@ export default function DadosBanco({ formik }) {
 
         </div>
         <div>
-          <label htmlFor="anoFundacao">Data da Fundação <span>*</span></label>
+          <label htmlFor="anoFundacao">Data da Fundação<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="anoFundacao"
@@ -89,7 +89,7 @@ export default function DadosBanco({ formik }) {
 
         </div>
       </div>
-      <label htmlFor="historiaBanco">História do Banco <span>*</span></label>
+      <label htmlFor="historiaBanco">História do Banco<span>*</span></label>
       <textarea
         className={style.container__ContainerForm_form_input}
         id="historiaBanco"

--- a/frontend/src/components/BancoForm/DadosEndereco/index.js
+++ b/frontend/src/components/BancoForm/DadosEndereco/index.js
@@ -36,7 +36,7 @@ export default function DadosEndereco({ formik }) {
 
   return (
     <>
-      <label htmlFor="cep">Cep <span>*</span></label>
+      <label htmlFor="cep">Cep<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="cep"
@@ -50,7 +50,7 @@ export default function DadosEndereco({ formik }) {
       {formik.touched.cep && formik.errors.endereco.cep ? (
         <span className={style.form__error}>{formik.errors.endereco.cep}</span>
       ) : null}
-      <label htmlFor="estado">Estado <span>*</span></label>
+      <label htmlFor="estado">Estado<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="estado"
@@ -64,7 +64,7 @@ export default function DadosEndereco({ formik }) {
       {formik.touched.estado && formik.errors.endereco.estado ? (
         <span className={style.form__error}>{formik.errors.endereco.estado}</span>
       ) : null}
-      <label htmlFor="cidade">Cidade <span>*</span></label>
+      <label htmlFor="cidade">Cidade<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="cidade"
@@ -78,7 +78,7 @@ export default function DadosEndereco({ formik }) {
       {formik.touched.cidade && formik.errors.endereco.cidade ? (
         <span className={style.form__error}>{formik.errors.endereco.cidade}</span>
       ) : null}
-      <label htmlFor="bairro">Bairro <span>*</span></label>
+      <label htmlFor="bairro">Bairro<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="bairro"
@@ -95,7 +95,7 @@ export default function DadosEndereco({ formik }) {
 
       <div className={style.container__ContainerForm_form_halfContainer}>
         <div>
-          <label htmlFor="logradouro">Logradouro <span>*</span></label>
+          <label htmlFor="logradouro">Logradouro<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="logradouro"
@@ -111,7 +111,7 @@ export default function DadosEndereco({ formik }) {
           ) : null}
         </div>
         <div>
-          <label htmlFor="numero">Número <span>*</span></label>
+          <label htmlFor="numero">Número<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             name="endereco.numero"

--- a/frontend/src/components/BancoForm/ObjetosBanco/index.js
+++ b/frontend/src/components/BancoForm/ObjetosBanco/index.js
@@ -5,7 +5,7 @@ export default function objetosBanco({ formik }) {
     <>
       <div className={style.container__ContainerForm_form_halfContainer}>
         <div>
-          <label htmlFor="bombona">Bombonas <span>*</span></label>
+          <label htmlFor="bombona">Bombonas<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="bombona"
@@ -22,7 +22,7 @@ export default function objetosBanco({ formik }) {
 
         </div>
         <div>
-          <label htmlFor="peneiraSelecao">Peneiras de seleção <span>*</span></label>
+          <label htmlFor="peneiraSelecao">Peneiras de Seleção<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="peneiraSelecao"
@@ -39,7 +39,7 @@ export default function objetosBanco({ formik }) {
 
         </div>
         <div>
-          <label htmlFor="balanca">Balanças <span>*</span></label>
+          <label htmlFor="balanca">Balanças<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="balanca"
@@ -56,7 +56,7 @@ export default function objetosBanco({ formik }) {
 
         </div>
         <div>
-          <label htmlFor="armario">Armários <span>*</span></label>
+          <label htmlFor="armario">Armários<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="armario"
@@ -73,7 +73,7 @@ export default function objetosBanco({ formik }) {
 
         </div>
         <div>
-          <label htmlFor="plantadeira">Plantadeiras <span>*</span></label>
+          <label htmlFor="plantadeira">Plantadeiras<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="plantadeira"
@@ -90,7 +90,7 @@ export default function objetosBanco({ formik }) {
 
         </div>
         <div>
-          <label htmlFor="Lonas">Lona <span>*</span></label>
+          <label htmlFor="Lonas">Lona<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="lona"
@@ -107,7 +107,7 @@ export default function objetosBanco({ formik }) {
 
         </div>
         <div>
-          <label htmlFor="batedeiraCereal">Batedeiras de cereais <span>*</span></label>
+          <label htmlFor="batedeiraCereal">Batedeiras de Cereais<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="batedeiraCereal"

--- a/frontend/src/components/BancoForm/agricultorForm.module.scss
+++ b/frontend/src/components/BancoForm/agricultorForm.module.scss
@@ -56,7 +56,7 @@
       label{
         margin: 0 0 0.5em 0;
         font-size: 1em;
-        font-weight: normal;
+        font-weight: bold;
         &span{
           color: red;
         }
@@ -92,7 +92,7 @@
         label{
           margin: 0 0 0.5em 0;
           font-size: 1em;
-          font-weight: normal;
+          font-weight: bold;
           &span{
             color: red;
           }
@@ -137,7 +137,7 @@
         label{
           margin: 0 0 0.5em 0;
           font-size: 0.8em;
-          font-weight: normal;
+          font-weight: bold;
 
         }
         &_input{

--- a/frontend/src/components/BancoForm/index.js
+++ b/frontend/src/components/BancoForm/index.js
@@ -91,14 +91,14 @@ const BancoForm = ({ diretorioAnterior, diretorioAtual, hrefAnterior }) => {
       />
 
       <div className={style.container__header}>
-        {etapas === 0 && <h1 className={style.container__header_currentNav}>1. Dados do banco</h1>}
-        {etapas >= 1 && etapas <= 2 && <h1 className={style.container__header_current}>1. Dados do banco</h1>}
+        {etapas === 0 && <h1 className={style.container__header_currentNav}>1. Dados do Banco</h1>}
+        {etapas >= 1 && etapas <= 2 && <h1 className={style.container__header_current}>1. Dados do Banco</h1>}
 
-        {etapas === 1 && <h1 className={style.container__header_currentNav}>2. Endereço do banco</h1>}
-        {etapas !== 1 && <h1 className={style.container__header_current}>2. Endereço do banco</h1>}
+        {etapas === 1 && <h1 className={style.container__header_currentNav}>2. Endereço do Banco</h1>}
+        {etapas !== 1 && <h1 className={style.container__header_current}>2. Endereço do Banco</h1>}
 
-        {etapas === 2 && <h1 className={style.container__header_currentNav}>3. Objetos do banco</h1>}
-        {etapas >= 0 && etapas < 2 && <h1 className={style.container__header_current}>3. Objetos do banco</h1>}
+        {etapas === 2 && <h1 className={style.container__header_currentNav}>3. Objetos do Banco</h1>}
+        {etapas >= 0 && etapas < 2 && <h1 className={style.container__header_current}>3. Objetos do Banco</h1>}
       </div>
 
       <div className={style.container__ContainerForm}>

--- a/frontend/src/components/CoordenadorForm/DadosEndereco/index.js
+++ b/frontend/src/components/CoordenadorForm/DadosEndereco/index.js
@@ -57,7 +57,7 @@ export default function DadosEndereco({ formik }) {
 
   return (
     <>
-      <label htmlFor="cep">Cep <span>*</span></label>
+      <label htmlFor="cep">Cep<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="cep"
@@ -71,7 +71,7 @@ export default function DadosEndereco({ formik }) {
       {formik.touched.cep && formik.errors.endereco.cep ? (
         <span className={style.form__error}>{formik.errors.endereco.cep}</span>
       ) : null}
-      <label htmlFor="estado">Estado <span>*</span></label>
+      <label htmlFor="estado">Estado<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="estado"
@@ -85,7 +85,7 @@ export default function DadosEndereco({ formik }) {
       {formik.touched.estado && formik.errors.endereco.estado ? (
         <span className={style.form__error}>{formik.errors.endereco.estado}</span>
       ) : null}
-      <label htmlFor="cidade">Cidade <span>*</span></label>
+      <label htmlFor="cidade">Cidade<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="cidade"
@@ -99,7 +99,7 @@ export default function DadosEndereco({ formik }) {
       {formik.touched.cidade && formik.errors.endereco.cidade ? (
         <span className={style.form__error}>{formik.errors.endereco.cidade}</span>
       ) : null}
-      <label htmlFor="bairro">Bairro <span>*</span></label>
+      <label htmlFor="bairro">Bairro<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="bairro"
@@ -116,7 +116,7 @@ export default function DadosEndereco({ formik }) {
 
       <div className={style.container__ContainerForm_form_halfContainer}>
         <div>
-          <label htmlFor="logradouro">Logradouro <span>*</span></label>
+          <label htmlFor="logradouro">Logradouro<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="logradouro"
@@ -132,7 +132,7 @@ export default function DadosEndereco({ formik }) {
           ) : null}
         </div>
         <div>
-          <label htmlFor="numero">Número <span>*</span></label>
+          <label htmlFor="numero">Número<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             name="endereco.numero"
@@ -178,7 +178,7 @@ export default function DadosEndereco({ formik }) {
         </div>
       </div>
       <div>
-        <label htmlFor="bancoId">Banco de sementes <span>*</span></label>
+        <label htmlFor="bancoId">Banco de Sementes<span>*</span></label>
         <select
           className={style.container__ContainerForm_form_halfContainer_input}
           id="bancoId"

--- a/frontend/src/components/CoordenadorForm/DadosUsuario/index.js
+++ b/frontend/src/components/CoordenadorForm/DadosUsuario/index.js
@@ -9,7 +9,7 @@ export default function DadosForm({ formik }) {
   return (
     <>
 
-      <label >E-mail <span>*</span></label>
+      <label >E-mail<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="email"
@@ -24,7 +24,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.email}</span>
       ) : null}
 
-      <label >Senha <span>*</span></label>
+      <label >Senha<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="senha"
@@ -39,7 +39,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.senha}</span>
       ) : null}
 
-      <label >Confirme sua senha <span>*</span></label>
+      <label >Confirme sua Senha<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="confirmarSenha"
@@ -54,7 +54,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.confirmarSenha}</span>
       ) : null}
 
-      <label >Nome <span>*</span></label>
+      <label >Nome<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="nome"
@@ -68,7 +68,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.nome}</span>
       ) : null}
 
-      <label >Apelido <span>*</span></label>
+      <label >Apelido<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="nomePopular"
@@ -82,7 +82,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.nomePopular}</span>
       ) : null}
 
-      <label >CPF <span>*</span></label>
+      <label >CPF<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_halfContainer_input}
         id="cpf"
@@ -101,7 +101,7 @@ export default function DadosForm({ formik }) {
       <div className={style.container__ContainerForm_form_halfContainer}>
 
         <div>
-          <label >Telefone <span>*</span></label>
+          <label >Telefone<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="contato"
@@ -119,7 +119,7 @@ export default function DadosForm({ formik }) {
         </div>
 
         <div>
-          <label >Data de Nascimento <span>*</span></label>
+          <label >Data de Nascimento<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="dataNascimento"
@@ -141,7 +141,7 @@ export default function DadosForm({ formik }) {
       <div className={style.container__ContainerForm_form_halfContainer}>
 
         <div>
-          <label >Sexo <span>*</span></label>
+          <label >Sexo<span>*</span></label>
           <select
             className={style.container__ContainerForm_form_halfContainer_input}
             id="sexo"
@@ -162,7 +162,7 @@ export default function DadosForm({ formik }) {
         </div>
 
         <div>
-          <label >Estado Civil <span>*</span></label>
+          <label >Estado Civil<span>*</span></label>
           <select
             className={style.container__ContainerForm_form_halfContainer_input}
             id="estadoCivil"
@@ -190,7 +190,7 @@ export default function DadosForm({ formik }) {
 
       {estadoCivil === '1' && (
         <div>
-          <label >Nome do Cônjuge <span>*</span></label>
+          <label >Nome do Cônjuge<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="conjugeNome"
@@ -205,7 +205,7 @@ export default function DadosForm({ formik }) {
             <span className={style.form__error}>{formik.errors['conjuge.nome']}</span>
           ) : null}
 
-          <label>Sexo do Cônjuge <span>*</span></label>
+          <label>Sexo do Cônjuge<span>*</span></label>
           <select
             className={style.container__ContainerForm_form_halfContainer_input}
             id="conjugeSexo"

--- a/frontend/src/components/CoordenadorForm/agricultorForm.module.scss
+++ b/frontend/src/components/CoordenadorForm/agricultorForm.module.scss
@@ -53,7 +53,7 @@
       label {
         margin: 0 0 0.5em 0;
         font-size: 1em;
-        font-weight: normal;
+        font-weight: bold;
 
         &span {
           color: red;

--- a/frontend/src/components/DetalhamentoBancoSemente/DadosBanco/index.js
+++ b/frontend/src/components/DetalhamentoBancoSemente/DadosBanco/index.js
@@ -11,7 +11,7 @@ export default function DadosBanco({ formik, editar }) {
           <div className={style.container__ContainerForm_form_threePartsContainer}>
 
             <div>
-              <label htmlFor="nome">Nome Banco</label>
+              <label htmlFor="nome">Nome do Banco</label>
               <input
                 className={style.container__ContainerForm_form_input}
                 placeholder="Não informado"

--- a/frontend/src/components/DetalhamentoBancoSemente/ObjetosBanco/index.js
+++ b/frontend/src/components/DetalhamentoBancoSemente/ObjetosBanco/index.js
@@ -20,7 +20,7 @@ export default function Dadosobjetos({ formik, editar }) {
 
             </div>
             <div>
-              <label htmlFor="peneirasSelecao">Poneiras de seleção </label>
+              <label htmlFor="peneirasSelecao">Peneiras de Seleção </label>
               <input
                 className={style.container__ContainerForm_form_input}
                 placeholder="Não informado"
@@ -74,7 +74,7 @@ export default function Dadosobjetos({ formik, editar }) {
 
             </div>
             <div>
-              <label htmlFor="batedeirasCereais">Batedeiras de cereais </label>
+              <label htmlFor="batedeirasCereais">Batedeiras de Cereais </label>
               <input
                 className={style.container__ContainerForm_form_input}
                 placeholder="Não informado"
@@ -86,7 +86,7 @@ export default function Dadosobjetos({ formik, editar }) {
             </div>
           </div>
           <div className={style.container__ContainerForm_form}>
-              <label htmlFor="historiaBanco">Historia Banco</label>
+              <label htmlFor="historiaBanco">História do Banco</label>
               <textarea
                 className={style.container__ContainerForm_form_input}
                 placeholder="Não informado"
@@ -202,7 +202,7 @@ export default function Dadosobjetos({ formik, editar }) {
 
             </div>
             <div>
-              <label htmlFor="batedeiraCereal">Batedeiras de cereais </label>
+              <label htmlFor="batedeiraCereal">Batedeiras de Cereais </label>
               <input
                 className={style.container__ContainerForm_form_halfContainer_input}
                 id="batedeiraCereal"
@@ -220,7 +220,7 @@ export default function Dadosobjetos({ formik, editar }) {
             </div>
           </div>
           <div >
-            <label htmlFor="historiaBanco" >Historia do Banco </label>
+            <label htmlFor="historiaBanco" >História do Banco </label>
             <textarea
               className={style.container__ContainerForm_form_halfContainer_input}
               id="historiaBanco"

--- a/frontend/src/components/DetalhamentoDoacao/DadosTransacao/index.js
+++ b/frontend/src/components/DetalhamentoDoacao/DadosTransacao/index.js
@@ -105,7 +105,7 @@ export default function DadosTransacao({ formik, hrefAtual }) {
 
                         </div>
                         <div>
-                            <label>Peso Kg</label>
+                            <label>Peso (Kg)</label>
                             <input
                                 type="number"
                                 name={`itens[${index}].peso`}

--- a/frontend/src/components/FuncionarioForm/DadosUsuario/index.js
+++ b/frontend/src/components/FuncionarioForm/DadosUsuario/index.js
@@ -5,11 +5,11 @@ import { useState } from "react";
 
 
 export default function DadosForm({ formik }) {
-  const [estadoCivil, setEstadoCivil] = useState(''); l
+  const [estadoCivil, setEstadoCivil] = useState('');
   return (
     <>
 
-      <label >E-mail <span>*</span></label>
+      <label >E-mail<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="email"
@@ -24,7 +24,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.email}</span>
       ) : null}
 
-      <label >Senha <span>*</span></label>
+      <label >Senha<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="senha"
@@ -39,7 +39,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.senha}</span>
       ) : null}
 
-      <label >Confirme a senha <span>*</span></label>
+      <label >Confirme a Senha<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="confirmarSenha"
@@ -54,7 +54,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.confirmarSenha}</span>
       ) : null}
 
-      <label >Nome <span>*</span></label>
+      <label >Nome<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_input}
         id="nome"
@@ -87,7 +87,7 @@ export default function DadosForm({ formik }) {
         className={style.container__ContainerForm_form_input}
         id="funcao"
         name="funcao"
-        placeholder="Insira a função do funcionário"
+        placeholder="Insira a função do colaborador(a)"
         onChange={formik.handleChange}
         onBlur={formik.handleBlur}
         value={formik.values.funcao}
@@ -96,7 +96,7 @@ export default function DadosForm({ formik }) {
         <span className={style.form__error}>{formik.errors.funcao}</span>
       ) : null}
 
-      <label >CPF <span>*</span></label>
+      <label >CPF<span>*</span></label>
       <input
         className={style.container__ContainerForm_form_halfContainer_input}
         id="cpf"
@@ -115,7 +115,7 @@ export default function DadosForm({ formik }) {
       <div className={style.container__ContainerForm_form_halfContainer}>
 
         <div>
-          <label >Telefone <span>*</span></label>
+          <label >Telefone<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="contato"
@@ -133,7 +133,7 @@ export default function DadosForm({ formik }) {
         </div>
 
         <div>
-          <label >Data de Nascimento <span>*</span></label>
+          <label >Data de Nascimento<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="dataNascimento"
@@ -155,7 +155,7 @@ export default function DadosForm({ formik }) {
       <div className={style.container__ContainerForm_form_halfContainer}>
 
         <div>
-          <label >Sexo <span>*</span></label>
+          <label >Sexo<span>*</span></label>
           <select
             className={style.container__ContainerForm_form_halfContainer_input}
             id="sexo"
@@ -176,7 +176,7 @@ export default function DadosForm({ formik }) {
         </div>
 
         <div>
-          <label >Estado Civil <span>*</span></label>
+          <label >Estado Civil<span>*</span></label>
           <select
             className={style.container__ContainerForm_form_halfContainer_input}
             id="estadoCivil"
@@ -204,7 +204,7 @@ export default function DadosForm({ formik }) {
 
       {estadoCivil === '1' && (
         <div>
-          <label >Nome do Cônjuge <span>*</span></label>
+          <label >Nome do Cônjuge<span>*</span></label>
           <input
             className={style.container__ContainerForm_form_halfContainer_input}
             id="conjugeNome"
@@ -219,7 +219,7 @@ export default function DadosForm({ formik }) {
             <span className={style.form__error}>{formik.errors['conjuge.nome']}</span>
           ) : null}
 
-          <label>Sexo do Cônjuge <span>*</span></label>
+          <label>Sexo do Cônjuge<span>*</span></label>
           <select
             className={style.container__ContainerForm_form_halfContainer_input}
             id="conjugeSexo"

--- a/frontend/src/components/FuncionarioForm/agricultorForm.module.scss
+++ b/frontend/src/components/FuncionarioForm/agricultorForm.module.scss
@@ -53,7 +53,7 @@
       label {
         margin: 0 0 0.5em 0;
         font-size: 1em;
-        font-weight: normal;
+        font-weight: bold;
 
         &span {
           color: red;

--- a/frontend/src/components/FuncionarioForm/index.js
+++ b/frontend/src/components/FuncionarioForm/index.js
@@ -110,11 +110,11 @@ const FuncionarioForm = ({ diretorioAnterior, diretorioAtual, hrefAnterior }) =>
       />
 
       <div className={style.container__header}>
-        {etapas === 0 && <h1 className={style.container__header_currentNav}>1. Dados do(a) Funcionário(a)</h1>}
-        {etapas >= 1 && etapas <= 2 && <h1 className={style.container__header_current}>1. Dados do(a) Funcionário(a)</h1>}
+        {etapas === 0 && <h1 className={style.container__header_currentNav}>1. Dados do(a) Colaborador(a)</h1>}
+        {etapas >= 1 && etapas <= 2 && <h1 className={style.container__header_current}>1. Dados do(a) Colaborador(a)</h1>}
 
-        {etapas === 1 && <h1 className={style.container__header_currentNav}>2. Endereço do(a) Funcionário(a)</h1>}
-        {etapas != 1 && <h1 className={style.container__header_current}>2. Endereço do(a) Funcionário(a)</h1>}
+        {etapas === 1 && <h1 className={style.container__header_currentNav}>2. Endereço do(a) Colaborador(a)</h1>}
+        {etapas != 1 && <h1 className={style.container__header_current}>2. Endereço do(a) Colaborador(a)</h1>}
 
       </div>
 

--- a/frontend/src/components/Header/header.module.scss
+++ b/frontend/src/components/Header/header.module.scss
@@ -96,6 +96,7 @@
         z-index: 1;
         display: flex;
         box-shadow: -3.5px 3.5px 8px rgba(0, 0, 0, 0.2);
+        z-index: 1000;
 
 
         &__conj{
@@ -241,6 +242,7 @@
         flex-direction: column;
         align-items: start;
         gap: 19px;
+        z-index: 1000;
 
         &__perfil{
             border: none;

--- a/frontend/src/components/ListFuncionarios/index.js
+++ b/frontend/src/components/ListFuncionarios/index.js
@@ -98,7 +98,7 @@ export default function ListFuncionarios({ diretorioAnterior, diretorioAtual, hr
 
               <Link className={style.header__container_link} href="funcionarios/novoFuncionario">
                 <h1>
-                  Adicionar Funcionário(a)
+                  Adicionar Colaborador(a)
                 </h1>
               </Link>
 

--- a/frontend/src/components/SementeForm/DadosSementesForm/index.js
+++ b/frontend/src/components/SementeForm/DadosSementesForm/index.js
@@ -67,7 +67,7 @@ export default function DadosSementesForm({ formik }) {
             <br />
             <div className={styles.sidedForm}>
                 <div>
-                    <label htmlFor="responsavelTecnico.nome">Responsável Técnico pelo Cadastro <span>*</span></label>
+                    <label htmlFor="responsavelTecnico.nome">Responsável Técnico pelo Cadastro<span>*</span></label>
                     <input
                         className={styles.sidedForm_input}
                         id="nome"
@@ -82,7 +82,7 @@ export default function DadosSementesForm({ formik }) {
                     ) : null}
                 </div>
                 <div>
-                    <label htmlFor="responsavelTecnico.cpf">CPF <span>*</span></label>
+                    <label htmlFor="responsavelTecnico.cpf">CPF<span>*</span></label>
                     <input
                         className={styles.sidedForm_input}
                         id="cpf"
@@ -135,7 +135,7 @@ export default function DadosSementesForm({ formik }) {
                 <br />
                 <div className={styles.sidedForm}>
                     <div>
-                        <label htmlFor="cultura.cultura">Cultura <span>*</span></label>
+                        <label htmlFor="cultura.cultura">Cultura<span>*</span></label>
                         <input
                             className={styles.sidedForm_input}
                             id="cultura"
@@ -150,7 +150,7 @@ export default function DadosSementesForm({ formik }) {
                         ) : null}
                     </div>
                     <div>
-                        <label htmlFor="cultura.genero">Gênero <span>*</span></label>
+                        <label htmlFor="cultura.genero">Gênero<span>*</span></label>
                         <input
                             className={styles.sidedForm_input}
                             id="genero"
@@ -167,7 +167,7 @@ export default function DadosSementesForm({ formik }) {
                         ) : null}
                     </div>
                     <div>
-                        <label htmlFor="nome">Nome da Cultivar <span>*</span></label>
+                        <label htmlFor="nome">Nome da Cultivar<span>*</span></label>
                         <input
                             className={styles.sidedForm_input}
                             id="nome"
@@ -184,7 +184,7 @@ export default function DadosSementesForm({ formik }) {
                     </div>
                 </div>
                 <div className={styles.checkbox}>
-                    <label htmlFor="finalidades" className={styles.checkbox__label}>Finalidade <span>*</span></label>
+                    <label htmlFor="finalidades" className={styles.checkbox__label}>Finalidade<span>*</span></label>
                     <div className={styles.checkbox__itens}>
                         {finalidades.map((finalidade) => (
                             <div key={finalidade.name}>
@@ -215,7 +215,7 @@ export default function DadosSementesForm({ formik }) {
             <div>
                 <div className={styles.sidedForm}>
                     <div className={styles.radio}>
-                        <label htmlFor="dominioPublico">Cultivar de Domínio Público <span>*</span></label>
+                        <label htmlFor="dominioPublico">Cultivar de Domínio Público<span>*</span></label>
                         <div className={styles.radio__itens}>
                             <input
                                 type="radio"
@@ -239,7 +239,7 @@ export default function DadosSementesForm({ formik }) {
                         </div>
                     </div>
                     <div>
-                        <label htmlFor="polinizaacaoAbertaMelhorada">Cultivar de Polinização Aberta Melhorada <span>*</span></label>
+                        <label htmlFor="polinizaacaoAbertaMelhorada">Cultivar de Polinização Aberta Melhorada<span>*</span></label>
                         <div className={styles.radio__itens}>
                             <input
                                 type="radio"
@@ -265,7 +265,7 @@ export default function DadosSementesForm({ formik }) {
                 </div>
                 <div className={styles.sidedForm}>
                     <div>
-                        <label htmlFor="nomePopular">Nome Popular da Cultivar <span>*</span></label>
+                        <label htmlFor="nomePopular">Nome Popular da Cultivar<span>*</span></label>
                         <input
                             className={styles.sidedForm_input}
                             id="nomePopular"
@@ -281,7 +281,7 @@ export default function DadosSementesForm({ formik }) {
 
                     </div>
                     <div>
-                        <label htmlFor="regioesAdaptacaoCultivo">Região de Adaptação da Cultivar <span>*</span></label>
+                        <label htmlFor="regioesAdaptacaoCultivo">Região de Adaptação da Cultivar<span>*</span></label>
                         <input
                             className={styles.sidedForm_input}
                             id="regioesAdaptacaoCultivo"

--- a/frontend/src/components/SementeForm/DadosToleranciaAdversidades/index.js
+++ b/frontend/src/components/SementeForm/DadosToleranciaAdversidades/index.js
@@ -30,7 +30,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
             <h1 className={styles.title}>Tolerância à adversidades</h1>
             <div className={styles.sidedForm}>
                 <div>
-                    <label htmlFor="toleranciaAdversidades.altaTemperatura">Alta Temperatura <span>*</span></label>
+                    <label htmlFor="toleranciaAdversidades.altaTemperatura">Alta Temperatura<span>*</span></label>
                     <select
                         className={styles.sidedForm_select}
                         id="altaTemperatura"
@@ -52,7 +52,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
                     ) : null}
                 </div>
                 <div>
-                    <label htmlFor="toleranciaAdversidades.baixaTemperatura">Baixa Temperatura <span>*</span></label>
+                    <label htmlFor="toleranciaAdversidades.baixaTemperatura">Baixa Temperatura<span>*</span></label>
                     <select
                         className={styles.sidedForm_select}
                         id="baixaTemperatura"
@@ -74,7 +74,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
                     ) : null}
                 </div>
                 <div>
-                    <label htmlFor="toleranciaAdversidades.Geada">Geada <span>*</span></label>
+                    <label htmlFor="toleranciaAdversidades.Geada">Geada<span>*</span></label>
                     <select
                         className={styles.sidedForm_select}
                         id="geada"
@@ -96,7 +96,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
                     ) : null}
                 </div>
                 <div>
-                    <label htmlFor="toleranciaAdversidades.chuvaExcessiva">Chuva Excessiva <span>*</span></label>
+                    <label htmlFor="toleranciaAdversidades.chuvaExcessiva">Chuva Excessiva<span>*</span></label>
                     <select
                         className={styles.sidedForm_select}
                         id="chuvaExcessiva"
@@ -118,7 +118,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
                     ) : null}
                 </div>
                 <div>
-                    <label htmlFor="toleranciaAdversidades.seca">Seca <span>*</span></label>
+                    <label htmlFor="toleranciaAdversidades.seca">Seca<span>*</span></label>
                     <select
                         className={styles.sidedForm_select}
                         id="seca"
@@ -140,7 +140,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
                     ) : null}
                 </div>
                 <div>
-                    <label htmlFor="toleranciaAdversidades.ventos">Ventos <span>*</span></label>
+                    <label htmlFor="toleranciaAdversidades.ventos">Ventos<span>*</span></label>
                     <select
                         className={styles.sidedForm_select}
                         id="ventos"
@@ -162,7 +162,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
                     ) : null}
                 </div>
                 <div>
-                    <label htmlFor="toleranciaAdversidades.salinidade">Salinidade <span>*</span></label>
+                    <label htmlFor="toleranciaAdversidades.salinidade">Salinidade<span>*</span></label>
                     <select
                         className={styles.sidedForm_select}
                         id="salinidade"
@@ -184,7 +184,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
                     ) : null}
                 </div>
                 <div>
-                    <label htmlFor="toleranciaAdversidades.toxidadeAluminio">Toxidade Alumínio <span>*</span></label>
+                    <label htmlFor="toleranciaAdversidades.toxidadeAluminio">Toxidade Alumínio<span>*</span></label>
                     <select
                         className={styles.sidedForm_select}
                         name="toleranciaAdversidades.toxidadeAluminio"
@@ -205,7 +205,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
                     ) : null}
                 </div>
                 <div>
-                    <label htmlFor="toleranciaAdversidades.soloArgiloso">Solo Argiloso <span>*</span></label>
+                    <label htmlFor="toleranciaAdversidades.soloArgiloso">Solo Argiloso<span>*</span></label>
                     <select
                         className={styles.sidedForm_select}
                         id="soloArgiloso"
@@ -227,7 +227,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
                     ) : null}
                 </div>
                 <div>
-                    <label htmlFor="toleranciaAdversidades.soloArenoso">Solo Arenoso <span>*</span></label>
+                    <label htmlFor="toleranciaAdversidades.soloArenoso">Solo Arenoso<span>*</span></label>
                     <select
                         className={styles.sidedForm_select}
                         id="soloArenoso"
@@ -249,7 +249,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
                     ) : null}
                 </div>
                 <div>
-                    <label htmlFor="toleranciaAdversidades.soloAcido">Solo Ácido <span>*</span></label>
+                    <label htmlFor="toleranciaAdversidades.soloAcido">Solo Ácido<span>*</span></label>
                     <select
                         className={styles.sidedForm_select}
                         id="soloAcido"
@@ -271,7 +271,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
                     ) : null}
                 </div>
                 <div >
-                    <label htmlFor="toleranciaAdversidades.soloBaixaFertilidade">Solo Baixa Fertilidade <span>*</span></label>
+                    <label htmlFor="toleranciaAdversidades.soloBaixaFertilidade">Solo Baixa Fertilidade<span>*</span></label>
                     <select
                         className={styles.sidedForm_select}
                         id="soloBaixaFertilidade"
@@ -298,7 +298,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
             <br />
             <div className={styles.sidedForm}>
                 <div>
-                    <label htmlFor="regiaoColetaDados">Região de Coleta dos Dados <span>*</span></label>
+                    <label htmlFor="regiaoColetaDados">Região de Coleta dos Dados<span>*</span></label>
                     <input
                         className={styles.sidedForm_input}
                         id="regiaoColetaDados"
@@ -361,7 +361,7 @@ export default function DadosCaracteristicasAgronomicas({ formik }) {
 
                 </div>
                 <div >
-                    <label htmlFor="imagens">Imagens <span>*</span></label>
+                    <label htmlFor="imagens">Imagens<span>*</span></label>
                     <input
                         className={styles.buttonImagens}
                         type="file"

--- a/frontend/src/components/SementeForm/SelecionarSementesBanco/index.js
+++ b/frontend/src/components/SementeForm/SelecionarSementesBanco/index.js
@@ -101,7 +101,7 @@ export default function SelecionarSementesBanco({ formik }) {
                     </div>
                     <div className={styles.container__ContainerForm_form_halfContainer}>
                         <div>
-                            <label>Peso <span>*</span></label>
+                            <label>Peso (Kg)<span>*</span></label>
                             <input
                                 className={styles.container__ContainerForm_form_halfContainer_input}
                                 type="text"

--- a/frontend/src/components/SementeForm/index.js
+++ b/frontend/src/components/SementeForm/index.js
@@ -191,14 +191,14 @@ const LayoutAdmin = ({ diretorioAnterior, diretorioAtual, hrefAnterior }) => {
       />
 
       <div className={styles.container__header}>
-        {etapas === 0 && <h1 className={styles.container__header_currentNav}>1. Dados da semente</h1>}
+        {etapas === 0 && <h1 className={styles.container__header_currentNav}>1. Dados da Semente</h1>}
         {etapas >= 1 && etapas <= 2 && <h1 className={styles.container__header_current}>1. Dados da Semente</h1>}
 
-        {etapas === 1 && <h1 className={styles.container__header_currentNav}>2. Dados da semente</h1>}
-        {etapas != 1 && <h1 className={styles.container__header_current}>2. Dados da semente</h1>}
+        {etapas === 1 && <h1 className={styles.container__header_currentNav}>2. Dados da Semente</h1>}
+        {etapas != 1 && <h1 className={styles.container__header_current}>2. Dados da Semente</h1>}
 
-        {etapas === 2 && <h1 className={styles.container__header_currentNav}>3. Dados da semente</h1>}
-        {etapas >= 0 && etapas < 2 && <h1 className={styles.container__header_current}>3. Dados da semente</h1>}
+        {etapas === 2 && <h1 className={styles.container__header_currentNav}>3. Dados da Semente</h1>}
+        {etapas >= 0 && etapas < 2 && <h1 className={styles.container__header_current}>3. Dados da Semente</h1>}
 
       </div>
 

--- a/frontend/src/components/TransacaoForm/DadosTransacao/index.js
+++ b/frontend/src/components/TransacaoForm/DadosTransacao/index.js
@@ -80,7 +80,7 @@ export default function DadosTransacao({ formik, hrefAnterior }) {
     return (
         <div>
             <div className={styles.container__ContainerForm_form}>
-                <label>Agricultor <span>*</span></label>
+                <label>Agricultor<span>*</span></label>
 
                 <input
                     type="text"
@@ -107,7 +107,7 @@ export default function DadosTransacao({ formik, hrefAnterior }) {
             {formik.values.itens.map((item, index) => (
                 <div key={index} className={styles.container__ContainerForm_form_halfContainer}>
                     <div>
-                        <label>Semente <span>*</span></label>
+                        <label>Semente<span>*</span></label>
                         <select
                             name={`itens[${index}].sementesId`}
                             onChange={(e) => handleSelectSementeChange(index, e.target.value)}
@@ -123,7 +123,7 @@ export default function DadosTransacao({ formik, hrefAnterior }) {
                         </select>
                     </div>
                     <div>
-                        <label>Peso <span>*</span> Kg</label>
+                        <label>Peso (Kg)<span>*</span></label>
                         <input
                             type="number"
                             name={`itens[${index}].peso`}
@@ -143,7 +143,7 @@ export default function DadosTransacao({ formik, hrefAnterior }) {
             </div>
             {hrefAnterior === "/doacoes" ? (
                 <>
-                    <label>Data da doação <span>*</span> </label>
+                    <label>Data da Doação<span>*</span> </label>
                     <input
                         type="date"
                         name="dataDoacao"

--- a/frontend/src/components/TransacaoForm/DadosTransacao/sementes.module.scss
+++ b/frontend/src/components/TransacaoForm/DadosTransacao/sementes.module.scss
@@ -71,8 +71,8 @@
 
       label {
         margin: 0 0 0.5em 0;
-        font-size: 1em;
-        font-weight: normal;
+        font-size: 2em;
+        font-weight: bold;
 
         &span {
           color: red;
@@ -111,7 +111,7 @@
         label {
           margin: 0 0 0.5em 0;
           font-size: 1em;
-          font-weight: normal;
+          font-weight: bold;
 
           &span {
             color: red;
@@ -163,7 +163,7 @@
         label {
           margin: 0 0 0.5em 0;
           font-size: 0.8em;
-          font-weight: normal;
+          font-weight: bold;
 
         }
 

--- a/frontend/src/components/TransacaoForm/agricultorForm.module.scss
+++ b/frontend/src/components/TransacaoForm/agricultorForm.module.scss
@@ -53,7 +53,7 @@
       label{
         margin: 0 0 0.5em 0;
         font-size: 1em;
-        font-weight: normal;
+        font-weight: bold;
         &span{
           color: red;
         }

--- a/frontend/src/components/searchUsuario/index.js
+++ b/frontend/src/components/searchUsuario/index.js
@@ -12,7 +12,7 @@ export function Search({ searchTerm, setSearchTerm }) {
         <input
           className={style.header__search_input}
           type="text"
-          placeholder="Pesquisar usuario..."
+          placeholder="Pesquisar Usuário..."
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
         />


### PR DESCRIPTION
Arrumei a label Nome banco para Nome do banco
Arrumei a label história banco para história do banco
Arrumei caixa alta misturada com caixa baixa
Coloquei acento em usuário (sim, isso era no filtro de pesquisa, por isso ninguém achava)
Coloquei negrito nos títulos dos campos do cadastro (em tudo)
Troquei agricultores por agricultores(as) em tudo
Arrumei o dropdown do header que ficava ocultada pelo carrossel
Arrumei o menu lateral que ficava ocultada pelo carrossel
Diminuí o espaçamento de todos os * em inputs obrigatórios
Arrumei o KG nas labels de peso